### PR TITLE
KTO-361: Prevent navigation menu bar horizontal overflow

### DIFF
--- a/src/main/static/src/components/Header.js
+++ b/src/main/static/src/components/Header.js
@@ -69,7 +69,6 @@ export default class Header extends React.Component {
             visibility:hover ? 'visible' : 'hidden',
             opacity: fade ? 100 : 0,
             height: hover ? 'auto' : 0,
-            width:'100%',
             borderLeft: borderColor,
             textAlign: 'left',
             transition: 'opacity ease .3s'

--- a/src/main/static/src/components/Raamit.js
+++ b/src/main/static/src/components/Raamit.js
@@ -422,7 +422,6 @@ export default class Raamit extends React.Component {
 
                             <div style={{
                                 display: 'flex',
-                                minWidth: 1200,
                                 boxShadow: this.state.fade ? '0px 1px 4px 0px rgba(0,0,0,0.20)' : '',
                                 transition: 'box-shadow .3s ease',
                                 zIndex: 1


### PR DESCRIPTION
- Menu links wrapper div doesn't need "min-width", because with home button width it causes the overflow and anyway the whole menu is collapsed  at width < 1225px.
- Navigation sub-menus (.nav-menu) don't need "width: 100%" because flexbox will automatically stretch the items ("align-items" default is "stretch"). By default the menu link border (separator) is not included in the width, which causes the menu to be over 100% wide.