### PR TITLE
TOR-1265 Lisää Valpas-linkki

### DIFF
--- a/src/main/static/src/dev/translation.json
+++ b/src/main/static/src/dev/translation.json
@@ -922,5 +922,19 @@
     "key": "tutkintotilaisuudet",
     "value": "Tutkintotilaisuudet",
     "locale": "fi"
+  },
+  {
+    "accesscount": 0,
+    "id": 26306,
+    "category": "virkailijaraamit",
+    "key": "valpas",
+    "accessed": 1612871902855,
+    "created": 1612871902855,
+    "createdBy": "1.2.246.562.24.16928167145",
+    "modified": 1612871902855,
+    "modifiedBy": "1.2.246.562.24.16928167145",
+    "force": false,
+    "locale": "fi",
+    "value": "VALPAS"
   }
 ]

--- a/src/main/static/src/resources/data.json
+++ b/src/main/static/src/resources/data.json
@@ -209,7 +209,7 @@
   },
   {
     "key":"rekisterit",
-    "requiresRole":["app_tiedonsiirto","app_suoritusrekisteri","app_koski","app_varda", "app_ehoks", "app_oikeustulkkirekisteri"],
+    "requiresRole":["app_tiedonsiirto","app_suoritusrekisteri","app_koski","app_varda", "app_ehoks", "app_oikeustulkkirekisteri", "app_valpas"],
     "links":[
       {
         "key":"koski",
@@ -240,6 +240,11 @@
         "key":"oikeustulkkirekisteri",
         "href":"/oikeustulkkirekisteri-ui",
         "requiresRole":["app_oikeustulkkirekisteri_oikeustulkki_crud"]
+      },
+      {
+        "key":"valpas",
+        "href":"/valpas/virkailija",
+        "requiresRole":["app_valpas"]
       }
     ]
   },


### PR DESCRIPTION
Pari kysymystä katselmoijalle:

(1) Syntyykö "app_valpas"-rooli automaattisesti, kun kayttooikeus-palveluun on jo lisätty palvelu nimeltä "VALPAS" (commit https://github.com/Opetushallitus/kayttooikeus/commit/b2ca3cf67fc297d254ddc41461de0cab39a6ea28) , ja sisään loganneella käyttäjällä on jokin käyttöoikeus kyseiseen palveluun? Vai pitääkö tätä integraatiota varten tehdä vielä jotain jossain muualla opintopolun palveluissa?

(2) Pitääkö lokalisaatiot luoda ennen tämän mergeä ja tuotantoonvientiä? Lisäsin lokalisaation toistaiseksi vain untuvalle.