### PR TITLE
OPHOTRKEH-215: removed old oikeustulkkirekisteri app from raamit

### DIFF
--- a/src/main/static/src/dev/translation.json
+++ b/src/main/static/src/dev/translation.json
@@ -1034,19 +1034,5 @@
     "key":"vkt",
     "value":"Valtionhallinnon kielitutkinnot",
     "locale":"fi"
-  },
-  {
-    "accesscount":0,
-    "id":32644,
-    "accessed":1659606356340,
-    "category":"virkailijaraamit",
-    "created":1659606356340,
-    "createdBy":"1.2.246.562.24.28593654916",
-    "modified":1659606356340,
-    "modifiedBy":"1.2.246.562.24.28593654916",
-    "force":false,
-    "key":"oikeustulkkirek",
-    "value":"Vanha oikeustulkkirekisteri",
-    "locale":"fi"
   }
 ]

--- a/src/main/static/src/resources/data.json
+++ b/src/main/static/src/resources/data.json
@@ -290,11 +290,6 @@
         "key":"vkt",
         "href":"/vkt/virkailija",
         "requiresRole":["app_vkt"]
-      },
-      {
-        "key":"oikeustulkkirek",
-        "href":"/oikeustulkkirekisteri-ui",
-        "requiresRole":["app_oikeustulkkirekisteri_oikeustulkki_crud"]
       }
     ]
   },


### PR DESCRIPTION
Voi halutessa deployata testiympäristöihin. Lokalisaatiot käännöspalvelussa pitää vielä päivittää eri ympäristöissä.